### PR TITLE
fix(student): lesson picker chips actually open the picked lesson

### DIFF
--- a/app/src/app/student/page.tsx
+++ b/app/src/app/student/page.tsx
@@ -85,7 +85,10 @@ export default async function StudentPage({
   }
 
   // No subject chosen yet → the per-subject home (never a blended score).
-  if (!subject) {
+  // A ?lesson= link IS a choice though: the picker's chips land here, and
+  // bouncing them to the home silently discarded the selection (field
+  // report, 2026-07-30: "picking another lesson brings me back").
+  if (!subject && !lessonSlug) {
     const summaries = await getSubjectSummaries(studentId);
     // Only show the home when more than one subject is loaded; otherwise the
     // single-subject check-in is the natural landing (math-only stays as-is).

--- a/app/src/components/student/LessonCheckIn.tsx
+++ b/app/src/components/student/LessonCheckIn.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link";
 import type { LessonData, LessonInfo } from "@/lib/types";
-import { isRtlSubject, subjectDef } from "@/lib/subjects";
+import { isRtlSubject, spineKeyOf, subjectDef } from "@/lib/subjects";
 import { masteryColor, pct } from "@/lib/mastery";
 
 /**
@@ -62,7 +62,10 @@ export function LessonCheckIn({
   }
 
   const isGeoModule = (id: string) => id.startsWith("module:geo");
-  const q = (slug: string) => `/student?lesson=${encodeURIComponent(slug)}`;
+  // Each chip carries ITS OWN lesson's subject, so the check-in it lands on
+  // filters the picker to the right course and the URL stays shareable.
+  const q = (slug: string, subject?: LessonInfo["subject"]) =>
+    `/student?${subject ? `subject=${spineKeyOf(subject)}&` : ""}lesson=${encodeURIComponent(slug)}`;
   const selectedIsGeo = lesson.slug.startsWith("geo");
 
   return (
@@ -313,7 +316,7 @@ export function LessonCheckIn({
                   return (
                     <Link
                       key={l.slug}
-                      href={q(l.slug)}
+                      href={q(l.slug, m.subject)}
                       scroll={false}
                       prefetch={false}
                       dir={soc ? "rtl" : undefined}


### PR DESCRIPTION
Field report from ainext.reletix.com: picking any lesson in «درس تاني؟» bounced back to the subject home.

**Cause:** picker chips linked to `/student?lesson=<slug>` without `subject`, and the page renders the subject home whenever `subject` is unset — the lesson param was never reached.

**Fix (two-sided):**
- `?lesson=` now counts as a chosen context: the home renders only when *neither* `subject` nor `lesson` is set.
- Every chip carries its own lesson's subject (`/student?subject=arabic&lesson=ara1-2`), so the check-in lands filtered to the right course and the URL is shareable.

**Verified locally:** the previously-failing URL opens ara1-2 «كُنْ جَمِيلًا»; `subject=arabic&lesson=ara2-2` opens «سميرة موسى» with its own LOs; cross-subject chips carry their own subject; learn/review door links unchanged. `tsc` clean.

Merging deploys code only — no data/migration steps needed for this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)