### PR TITLE
PoC: visible student picker + create-student + promote-poc bulk promotion

### DIFF
--- a/.github/workflows/refresh-content.yml
+++ b/.github/workflows/refresh-content.yml
@@ -18,7 +18,7 @@ on:
         type: choice
         required: true
         default: preview
-        options: [preview, course, full-reseed, status]
+        options: [preview, course, full-reseed, status, promote-poc]
       course:
         description: "Course node id — for preview and course modes"
         type: string
@@ -64,6 +64,11 @@ jobs:
                 echo "::error::full-reseed replaces the WHOLE database (student attempts and mastery included). Type FULL-RESEED in the confirm box to proceed."
                 exit 1
               fi ;;
+            promote-poc)
+              if [ "$CONFIRM" != "PROMOTE-POC" ]; then
+                echo "::error::promote-poc marks EVERY review question live, attributed to Samuel (PoC bulk). Type PROMOTE-POC in the confirm box to proceed."
+                exit 1
+              fi ;;
             *) echo "::error::unknown mode '$MODE'"; exit 1 ;;
           esac
           # Exact match, anchored: a course id and nothing else. (refresh-content.sh
@@ -106,6 +111,7 @@ jobs:
             preview)     set -- preview "$COURSE" ;;
             course)      set -- course  "$COURSE" ;;
             full-reseed) set -- full-reseed ;;
+            promote-poc) set -- promote-poc ;;
           esac
           # `bash …`: immune to a lost exec bit. tee: the summary step reads the log.
           bash ./refresh-content.sh "$@" 2>&1 | tee "$RUNNER_TEMP/refresh.log"

--- a/app/src/app/api/demo-students/route.ts
+++ b/app/src/app/api/demo-students/route.ts
@@ -1,0 +1,44 @@
+import { pool } from "@/lib/db";
+import { listDemoStudents } from "@/lib/student-context";
+
+/**
+ * Demo student roster — PoC ONLY, and deliberately NOT auth (PRD §3).
+ *
+ * GET  → the seeded cast with live counters (what the switcher panel shows).
+ * POST → create a new demo student {name} and return {id}; the client then
+ *        sets the plain demo cookie itself (lib/demo-student.ts) and
+ *        refreshes. Grade is pinned to prep-3 — the PoC's only cohort.
+ *
+ * Every row this creates is equally visible to whoever can open the demo
+ * site (it is behind Cloudflare Access); no credentials, no PII beyond a
+ * display name. Real accounts (parent-owned, phone+OTP) arrive with the
+ * student PWA and replace this file.
+ */
+
+export const dynamic = "force-dynamic";
+
+export async function GET() {
+  return Response.json({ students: await listDemoStudents() });
+}
+
+export async function POST(req: Request) {
+  let name = "";
+  try {
+    const body = (await req.json()) as { name?: unknown };
+    name = typeof body.name === "string" ? body.name.trim() : "";
+  } catch {
+    /* fall through to the validation error */
+  }
+  if (name.length < 2 || name.length > 40) {
+    return Response.json(
+      { error: "name must be 2–40 characters" },
+      { status: 400 }
+    );
+  }
+  const res = await pool.query(
+    `INSERT INTO students (display_name, grade) VALUES ($1, 'prep-3')
+     RETURNING id`,
+    [name]
+  );
+  return Response.json({ id: Number(res.rows[0].id) }, { status: 201 });
+}

--- a/app/src/app/student/page.tsx
+++ b/app/src/app/student/page.tsx
@@ -94,7 +94,22 @@ export default async function StudentPage({
     // single-subject check-in is the natural landing (math-only stays as-is).
     if (summaries.length > 1)
       return withSwitcher(
-        <SubjectHome summaries={summaries} studentName={studentName} />
+        <>
+          {/* PoC (Samuel, 2026-07-30): a VISIBLE "who's studying?" dropdown
+              on the home — pick a profile or create a new demo student.
+              The hidden triple-tap variants stay on the other surfaces. */}
+          <div
+            dir="rtl"
+            className="mx-auto flex max-w-5xl items-center justify-end px-6 pt-5"
+          >
+            <DemoStudentSwitcher
+              students={students}
+              currentId={studentId}
+              visible
+            />
+          </div>
+          <SubjectHome summaries={summaries} studentName={studentName} />
+        </>
       );
   }
 

--- a/app/src/components/DemoStudentSwitcher.tsx
+++ b/app/src/components/DemoStudentSwitcher.tsx
@@ -35,27 +35,44 @@ export function DemoStudentSwitcher({
   students,
   currentId,
   children,
+  visible = false,
 }: {
   students: DemoStudent[];
   currentId: number;
   /** wrapped element = the (invisible) trigger; omit for a corner hot-zone */
   children?: ReactNode;
+  /** PoC (Samuel, 2026-07-30): render a VISIBLE profile dropdown — single
+   *  click, normal button showing the current student — instead of the
+   *  hidden triple-tap affordance. The hidden variants stay for the lesson
+   *  surfaces; this one fronts the student home as a "who's studying?" pick. */
+  visible?: boolean;
 }) {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [creating, setCreating] = useState(false);
   const wrapRef = useRef<HTMLSpanElement>(null);
   // The panel is position:FIXED, anchored to the trigger's measured rect.
   // An absolutely-positioned panel would be painted under later siblings —
   // the page sections each create their own stacking context (anim-rise), so
   // "z-50 inside an earlier section" still loses to the graph card.
-  const [pos, setPos] = useState<{ top: number; right: number } | null>(null);
+  const [pos, setPos] = useState<{
+    top: number;
+    left?: number;
+    right?: number;
+  } | null>(null);
   const toggle = useCallback(() => {
     const r = wrapRef.current?.getBoundingClientRect();
     if (r) {
-      setPos({
-        top: r.bottom + 8,
-        right: Math.max(12, window.innerWidth - r.right),
-      });
+      const vw = window.innerWidth;
+      // anchor to whichever side keeps the 19rem panel on-screen — the
+      // visible trigger sits at the RTL start (left edge), where a
+      // right-anchored panel clips off the viewport
+      setPos(
+        r.left < vw / 2
+          ? { top: r.bottom + 8, left: Math.max(12, r.left) }
+          : { top: r.bottom + 8, right: Math.max(12, vw - r.right) }
+      );
     }
     setOpen((o) => !o);
   }, []);
@@ -81,19 +98,40 @@ export function DemoStudentSwitcher({
     [router]
   );
 
+  const current = students.find((s) => s.id === currentId);
+
   return (
     <span ref={wrapRef} className="relative inline-block" dir="ltr">
-      {children && (
-        <span
-          onClick={onTap}
-          className="cursor-default select-none"
-          title="" /* no hint: students must not discover this */
+      {visible ? (
+        // PoC profile dropdown: one click, clearly labeled (not the hidden
+        // founders' gesture) — "who's studying today?"
+        <button
+          onClick={toggle}
+          dir="rtl"
+          aria-haspopup="listbox"
+          aria-expanded={open}
+          className="flex items-center gap-2 rounded-full border border-line bg-card px-3.5 py-1.5 text-[13px] font-medium text-ink shadow-sm transition-all duration-150 hover:-translate-y-px hover:border-accent/50"
         >
-          {children}
-        </span>
+          <span aria-hidden>👤</span>
+          {current?.displayName ?? "الطالب"}
+          <span className="text-[10px] text-ink-faint" aria-hidden>
+            ▾
+          </span>
+        </button>
+      ) : (
+        children && (
+          <span
+            onClick={onTap}
+            className="cursor-default select-none"
+            title="" /* no hint: students must not discover this */
+          >
+            {children}
+          </span>
+        )
       )}
       {mounted &&
         !children &&
+        !visible &&
         createPortal(
           // bottom-RIGHT on purpose: Next's dev-tools badge owns the bottom-left
           <span
@@ -114,9 +152,13 @@ export function DemoStudentSwitcher({
             onClick={() => setOpen(false)}
           />
           <div
-            style={children && pos ? { top: pos.top, right: pos.right } : undefined}
+            style={
+              (children || visible) && pos
+                ? { top: pos.top, left: pos.left, right: pos.right }
+                : undefined
+            }
             className={`ledger-card fixed z-[61] w-[19rem] p-3 text-left shadow-xl ${
-              children ? "" : "bottom-12 right-3"
+              children || visible ? "" : "bottom-12 right-3"
             }`}
           >
             <p className="rule-label mb-2">Demo student · not auth</p>
@@ -166,6 +208,47 @@ export function DemoStudentSwitcher({
                 </li>
               )}
             </ul>
+
+            {/* PoC: create a fresh demo student in place (POST /api/demo-students) */}
+            <form
+              dir="rtl"
+              className="mt-2 flex items-center gap-1.5 border-t border-line-soft px-1 pt-2.5"
+              onSubmit={async (e) => {
+                e.preventDefault();
+                const name = newName.trim();
+                if (name.length < 2 || creating) return;
+                setCreating(true);
+                try {
+                  const res = await fetch("/api/demo-students", {
+                    method: "POST",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ name }),
+                  });
+                  if (res.ok) {
+                    const j = (await res.json()) as { id: number };
+                    setNewName("");
+                    choose(j.id); // switch to the newborn + refresh the roster
+                  }
+                } finally {
+                  setCreating(false);
+                }
+              }}
+            >
+              <input
+                value={newName}
+                onChange={(e) => setNewName(e.target.value)}
+                placeholder="طالب جديد — الاسم"
+                maxLength={40}
+                className="min-w-0 flex-1 rounded-lg border border-line bg-paper px-2.5 py-1.5 text-[13px] text-ink outline-none focus:border-accent/60"
+              />
+              <button
+                type="submit"
+                disabled={creating || newName.trim().length < 2}
+                className="rounded-lg bg-ink px-3 py-1.5 text-[12px] font-semibold text-paper transition-colors disabled:opacity-40"
+              >
+                {creating ? "…" : "أضف +"}
+              </button>
+            </form>
             <p className="mt-2 px-2.5 font-mono text-[10px] leading-relaxed text-ink-faint">
               demo affordance — a cookie, validated server-side. Not a login.
             </p>

--- a/deploy/refresh-content.sh
+++ b/deploy/refresh-content.sh
@@ -284,6 +284,33 @@ case "$MODE" in
     info "roll back with:  $0 restore $LAST_BACKUP"
     ;;
 
+  promote-poc)
+    # ============================ PoC ONLY ============================
+    # Samuel's explicit call (2026-07-30): during the PoC phase every
+    # extracted question is servable — he bulk-approves as the product's
+    # review authority, exactly like the maths PoC's --approve-all. The
+    # promotion is RECORDED (reviewed_by), backed up first, and reversible.
+    # The pre-pilot admin review tool replaces this before real students.
+    # The loader's sacred-bundle --approve-all refusal and the runtime
+    # sacred-containment guard are deliberately untouched.
+    preflight
+    say "PoC promotion — every 'review' question goes live, attributed to Samuel"
+    info "before: $(counts)"
+    backup promote-poc
+    n=$(dbq "WITH p AS (
+               UPDATE questions
+                  SET status='live',
+                      reviewed_by='samuel (poc bulk promote)',
+                      reviewed_at=now()
+                WHERE status='review'
+               RETURNING 1)
+             SELECT count(*) FROM p")
+    info "promoted: $n question(s)"
+    info "after:  $(counts)"
+    say "Done"
+    info "roll back with:  $0 restore $LAST_BACKUP"
+    ;;
+
   restore)
     [ $# -ge 1 ] || usage
     preflight


### PR DESCRIPTION
Samuel's PoC directives: bypass the human review queue for questions, and make student profiles a first-class visible control.

## Student profiles
- **Visible dropdown on the student home** — current profile + one-click switching (the hidden triple-tap variants remain on the other surfaces).
- **«طالب جديد» in the panel** — creates a demo student via `POST /api/demo-students` (name only, grade pinned prep-3), switches to them instantly. Demo affordance, not auth (PRD §3).
- Verified live in browser: created «مريم (تجربة)» → fresh 0% profile, greeted by name.

## PoC bulk promotion (data — run AFTER merge)
New **`promote-poc`** mode in the Content-refresh workflow: marks every `review` question `live`, attributed `reviewed_by='samuel (poc bulk promote)'` (same precedent as the maths PoC's bulk approval), with a pg_dump backup first and a typed `PROMOTE-POC` confirmation. Reversible via `restore`.

**Deliberately untouched:** the loader still hard-refuses `--approve-all` on sacred bundles, and the runtime sacred-containment guard still scans every chat surface — promotion changes question status, not the scripture-handling guarantees.

## After merge
1. Deploy runs automatically (code).
2. Actions → **Content refresh** → mode `promote-poc`, confirm `PROMOTE-POC` → all 576 review questions (Arabic + social) go live on the box.

`tsc` clean · 48/48 tests · `next build` clean · shell syntax checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Unauthenticated demo-student creation and a one-click DB promotion of all review questions affect PoC data and what students can be served, but scope is explicitly PoC/demo (Cloudflare Access, reversible backups) rather than production auth.
> 
> **Overview**
> **PoC student profiles** — On the multi-subject student home, a **visible** profile dropdown replaces the founders-only triple-tap for picking who is studying. The switcher panel can **create** a new demo student (name only, grade pinned to prep-3) via a new unauthenticated `GET/POST /api/demo-students` route; the client sets the existing demo cookie and refreshes. Hidden triple-tap switchers remain on other surfaces.
> 
> **PoC bulk question promotion** — Content refresh adds **`promote-poc`** (workflow + `refresh-content.sh`): after backup and typed `PROMOTE-POC` confirmation, every question in `review` is set to `live` with `reviewed_by` recorded as Samuel’s bulk promote. Rollback via restore. Loader `--approve-all` refusal and sacred-containment runtime checks are **not** changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b01d893244373b58b5346c30ff81d78cd1e1614. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->